### PR TITLE
CI: Update to use current builtin actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: package install
       run: ./ci_prereq.sh


### PR DESCRIPTION
Older actions use deprecated node12, so update to avoid the warning.